### PR TITLE
Fixing up be_routable

### DIFF
--- a/lib/spec/rails/matchers/route_to.rb
+++ b/lib/spec/rails/matchers/route_to.rb
@@ -101,7 +101,7 @@ module Spec
             false
           rescue ::Test::Unit::AssertionFailedError => e
             # the second thingy will always be "<{}>" becaues of the way we called assert_recognizes({}...) above.
-            e.to_s =~ /<(.*)> did not match <\{\}>/ and @actual_place = $1 or raise
+            e.to_s =~ /<(.*)> did not match <\{\}>/m and @actual_place = $1 or raise
             true
           end
         end

--- a/spec/spec/rails/example/shared_routing_example_group_examples.rb
+++ b/spec/spec/rails/example/shared_routing_example_group_examples.rb
@@ -114,6 +114,10 @@ shared_examples_for "a be routable spec" do
           self.stub!( :assert_recognizes ).and_return { raise ::Test::Unit::AssertionFailedError, "<{a}> did not match <{}>" }
           { :get => "/rspec_on_rails_spec/arguably_bad_route" }.should be_routable
         end
+        it "should be_routable even when Test::Unit::AssertionFailedError has line breaks in the message" do
+          self.stub!( :assert_recognizes ).and_return { raise ::Test::Unit::AssertionFailedError, "<{a => b,\nc => d}> did not match <{}>" }
+          { :get => "/rspec_on_rails_spec/arguably_bad_route" }.should be_routable
+        end
         it "should re-raise on unusual Test::Unit::AssertionFailedError" do
           self.stub!( :assert_recognizes ).and_return { raise ::Test::Unit::AssertionFailedError, "some other message" }
           expect { { :get => "/rspec_on_rails_spec/weird_case_route/" }.should be_routable }.


### PR DESCRIPTION
Making be_routable matcher a bit more robust (will match through linebreaks).

I had run into this issue where the regex used to match the error message from `assert_recognizes` failed to match because the portion of the message that is normally of the format "{:controller => :foo, :action => :bar}" sometimes has line breaks in it, causing actual routable paths to fail the check.

This simply enables multiline matching on that regex.

linked issue: https://github.com/dchelimsky/rspec-rails/issues/8 (not sure how to _actually_ link to that issue so this pull request shows up in that thread)
