### PR TITLE
Include the Rake::DSL module manually to remove deprecation messages from

### DIFF
--- a/generators/rspec/templates/rspec.rake
+++ b/generators/rspec/templates/rspec.rake
@@ -24,6 +24,8 @@ rescue MissingSourceFile
   module Spec
     module Rake
       class SpecTask
+        include ::Rake::DSL
+
         def initialize(name)
           task name do
             # if rspec-rails is a configured gem, this will output helpful material and exit ...

--- a/generators/rspec/templates/rspec.rake
+++ b/generators/rspec/templates/rspec.rake
@@ -24,7 +24,9 @@ rescue MissingSourceFile
   module Spec
     module Rake
       class SpecTask
-        include ::Rake::DSL
+        if defined?(::Rake::DSL)
+          include ::Rake::DSL
+        end
 
         def initialize(name)
           task name do


### PR DESCRIPTION
Include the Rake::DSL module manually to remove deprecation messages from Rake 0.9.2.
