### PR TITLE
Explictly stub valid? in mock_model

### DIFF
--- a/lib/spec/rails/mocks.rb
+++ b/lib/spec/rails/mocks.rb
@@ -16,6 +16,7 @@ module Spec
           :new_record? => false,
           :destroyed? => false,
           :marked_for_destruction? => false,
+          :valid? => true,
           :errors => stub("errors", :count => 0)
         })
         m = mock("#{model_class.name}_#{id}", options_and_stubs)

--- a/spec/spec/rails/mocks/mock_model_spec.rb
+++ b/spec/spec/rails/mocks/mock_model_spec.rb
@@ -30,6 +30,9 @@ describe "mock_model" do
     it "should say it is not marked_for_destruction" do
       @model.marked_for_destruction?.should be(false)
     end
+    it "should say if it is valid" do
+      @model.valid?.should be(true)
+    end
   end
 
   describe "with params" do


### PR DESCRIPTION
It's not uncommon to check if the model is valid, and this is mocked by default in newer rspec-rails as well (https://github.com/rspec/rspec-rails/commit/a10c402405b50267bf922f94084eef055502daa9). I think it might be useful to backport.
