### PR TITLE
Compatibility with Rails LTS 2.3.18.16

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,35 @@
+PATH
+  remote: .
+  specs:
+    rspec-rails (1.3.4)
+      rack (>= 1.0.0)
+      rspec (~> 1.3.1)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    builder (3.2.2)
+    cucumber (1.3.20)
+      builder (>= 2.1.2)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    diff-lcs (1.2.5)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
+    multi_json (1.11.2)
+    multi_test (0.1.2)
+    rack (1.4.7)
+    rspec (1.3.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cucumber (>= 0.3.99)
+  rack (= 1.4.7)
+  rspec-rails!
+
+BUNDLED WITH
+   1.16.1

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,3 +1,12 @@
+= rspec-rails 1.x for Rails 2.3 LTS
+
+This is a maintenance fork of `rspec-rails` 1.x to be used with {Rails 2.3 LTS}[https://railslts.com].
+
+There is also a {maintenance fork of `rspec-rails` 2.x}[https://github.com/makandra/rspec-rails/tree/2-14-lts] to be used with {Rails 3.2 LTS}(https://railslts.com).
+
+If you are looking for modern versions of this gem, see http://github.com/rspec/rspec-rails.
+
+
 = Spec::Rails
 
 * http://rspec.info
@@ -12,9 +21,6 @@ Behaviour Driven Development for Ruby on Rails.
 
 rspec-rails is an RSpec extension that allows you to drive the development of
 Ruby on Rails applications with RSpec.
-
-This is the repository for rspec-rails-1.x. If you're looking
-for rspec-rails-2 for rails-3, see http://github.com/rspec/rspec-rails.
 
 == FEATURES:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,8 +1,8 @@
-= rspec-rails 1.x for Rails 2.3 LTS
+= rspec-rails 1.3 for Rails 2.3 LTS
 
-This is a maintenance fork of +rspec-rails+ 1.x to be used with {Rails 2.3 LTS}[https://railslts.com].
+This is a maintenance fork of +rspec-rails+ 1.3 to be used with {Rails 2.3 LTS}[https://railslts.com].
 
-There is also a {maintenance fork of +rspec-rails+ 2.x}[https://github.com/makandra/rspec-rails/tree/2-14-lts] to be used with {Rails 3.2 LTS}[https://railslts.com].
+There is also a {maintenance fork of +rspec-rails+ 2.14}[https://github.com/makandra/rspec-rails/tree/2-14-lts] to be used with {Rails 3.2 LTS}[https://railslts.com].
 
 If you are looking for modern versions of this gem, see http://github.com/rspec/rspec-rails.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,8 +1,8 @@
 = rspec-rails 1.x for Rails 2.3 LTS
 
-This is a maintenance fork of `rspec-rails` 1.x to be used with {Rails 2.3 LTS}[https://railslts.com].
+This is a maintenance fork of +rspec-rails+ 1.x to be used with {Rails 2.3 LTS}[https://railslts.com].
 
-There is also a {maintenance fork of `rspec-rails` 2.x}[https://github.com/makandra/rspec-rails/tree/2-14-lts] to be used with {Rails 3.2 LTS}(https://railslts.com).
+There is also a {maintenance fork of +rspec-rails+ 2.x}[https://github.com/makandra/rspec-rails/tree/2-14-lts] to be used with {Rails 3.2 LTS}(https://railslts.com).
 
 If you are looking for modern versions of this gem, see http://github.com/rspec/rspec-rails.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,7 @@
 
 This is a maintenance fork of +rspec-rails+ 1.x to be used with {Rails 2.3 LTS}[https://railslts.com].
 
-There is also a {maintenance fork of +rspec-rails+ 2.x}[https://github.com/makandra/rspec-rails/tree/2-14-lts] to be used with {Rails 3.2 LTS}(https://railslts.com).
+There is also a {maintenance fork of +rspec-rails+ 2.x}[https://github.com/makandra/rspec-rails/tree/2-14-lts] to be used with {Rails 3.2 LTS}[https://railslts.com].
 
 If you are looking for modern versions of this gem, see http://github.com/rspec/rspec-rails.
 

--- a/lib/spec/rails/example/controller_example_group.rb
+++ b/lib/spec/rails/example/controller_example_group.rb
@@ -195,6 +195,7 @@ MESSAGE
           def record_render(opts)
             return unless @_rendered
             @_rendered[:template] ||= opts[:file] if opts[:file]
+            @_rendered[:template] ||= opts[:file_in_view_path] if opts[:file_in_view_path]
             @_rendered[:partials][opts[:partial]] += 1 if opts[:partial]
           end
 

--- a/lib/spec/rails/version.rb
+++ b/lib/spec/rails/version.rb
@@ -4,7 +4,7 @@ module Spec # :nodoc:
       unless defined? MAJOR
         MAJOR  = 1
         MINOR  = 3
-        TINY   = 4
+        TINY   = 5
         PRE    = nil
       
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/lib/spec/rails/version.rb
+++ b/lib/spec/rails/version.rb
@@ -4,7 +4,7 @@ module Spec # :nodoc:
       unless defined? MAJOR
         MAJOR  = 1
         MINOR  = 3
-        TINY   = 5
+        TINY   = 4
         PRE    = nil
       
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')


### PR DESCRIPTION
I apologize for making a PR for this very old branch.

We are [still maintaining Rails 2.3](https://railslts.com). A patch [CVE-2016-2098](https://groups.google.com/forum/#!topic/rubyonrails-security/ly-IH-fxr_Q) has changed the default render type of `render 'template'` (it used to be `render :file => 'template'`).

This also breaks the `render_template` matcher in this gem, which [overrides the `render` method](https://github.com/dchelimsky/rspec-rails/blob/master/lib/spec/rails/example/controller_example_group.rb#L195) in ActionController to track which template has been rendered.

The attached commit repairs that matcher for recent versions of Rails LTS (1 line changed).

I wonder if you can be bothered to `rake release` this as a new version 1.3.5?

Again, sorry for this blast from the past.
